### PR TITLE
Fixing deprecated configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -10,7 +10,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('wizards_rest');
+        $rootNode = $treeBuilder->getRootNode('wizards_rest');
 
         $rootNode
             ->children()


### PR DESCRIPTION
Just changing the configuration `TreeBuilder` as `$treebuilder->root()` is deprecated in Symfony 4.2 and will be removed in 5.0 as you can see [here](https://symfony.com/blog/new-in-symfony-4-2-important-deprecations).